### PR TITLE
Scrum 255 feedback only possible after activity end

### DIFF
--- a/models/feedback.py
+++ b/models/feedback.py
@@ -1,11 +1,11 @@
 from dependencies.database import Base
-from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy import Column, Integer, String, Text, ForeignKey
 
 class Feedback(Base):
     __tablename__ = "feedbacks"
 
     id = Column(Integer, primary_key=True, index=True)
-    activity_id = Column(Integer, nullable=False)
+    activity_id = Column(Integer, ForeignKey("activities.id"), nullable=True)
     rating = Column(Integer, nullable=True)
     comment = Column(Text, nullable=True)
     user_id = Column(String, nullable=False)

--- a/router/feedback.py
+++ b/router/feedback.py
@@ -1,119 +1,34 @@
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException
 from sqlalchemy.orm import Session
-from services.ui.plugin_settings import get_plugin_setting_by_title
+from typing import List
 from dependencies.database import get_db
 from dependencies.auth import get_current_user
-from ..models.feedback import Feedback as FeedbackModel
 from ..schemas.feedback import FeedbackCreate, FeedbackResponse
+from ..services.feedback_service import FeedbackService
 from utils.api import Router
-from typing import List
-from models.activity import Activity
 
 router = Router()
 
-def get_user_id(user: dict):
-    return user.get("sub") if user else user.get("anonymous_id")
-
 @router.post("/{activity_id}", response_model=FeedbackResponse)
-async def submit_feedback(
-    activity_id: int,
-    data: FeedbackCreate,
-    db: Session = Depends(get_db),
-    user: dict = Depends(get_current_user(force_auth=False))
-):
-    user_id = get_user_id(user)
-
-    activity = db.query(Activity).filter(Activity.id == activity_id).first()
-    if activity is None:
-        raise HTTPException(status_code=404, detail="Activity not found")
-
-    existing_feedback = db.query(FeedbackModel).filter_by(activity_id=activity_id, user_id=user_id).first()
-    if existing_feedback:
-        raise HTTPException(status_code=400, detail="User has already submitted feedback for this activity")
-
-    settings = await get_plugin_setting_by_title("activities-feedback-plugin")
-    inputs = {input.title: input for input in settings.inputs}
-
-    require_rating = inputs.get("Require Rating")
-    if require_rating and require_rating.options and require_rating.options[0] == "Yes":
-        if not (1 <= data.rating <= 5):
-            raise HTTPException(status_code=400, detail="Rating is required and must be between 1 and 5.")
-
-    allow_comments = inputs.get("Allow Comments")
-    if allow_comments and allow_comments.options and allow_comments.options[0] == "No":
-        data.comment = None
-
-    feedback = FeedbackModel(
-        activity_id=activity_id,
-        rating=data.rating,
-        comment=data.comment,
-        user_id=user_id
-    )
-
-    db.add(feedback)
-    db.commit()
-    db.refresh(feedback)
-
-    return feedback
+async def submit_feedback(activity_id: int, data: FeedbackCreate, db: Session = Depends(get_db), user: dict = Depends(get_current_user(force_auth=False))):
+    return await FeedbackService(db).create(activity_id, data, user)
 
 @router.get("/", response_model=List[FeedbackResponse])
 def list_feedback(db: Session = Depends(get_db)):
-    return db.query(FeedbackModel).all()
+    return FeedbackService(db).get_all()
 
 @router.get("/{activity_id}/all", response_model=List[FeedbackResponse])
-def get_feedbacks_for_activity(
-    activity_id: int,
-    db: Session = Depends(get_db),
-):
-    return db.query(FeedbackModel).filter_by(activity_id=activity_id).all()
-
+def get_feedbacks_for_activity(activity_id: int, db: Session = Depends(get_db)):
+    return FeedbackService(db).get_by_activity(activity_id)
 
 @router.get("/{activity_id}/me", response_model=FeedbackResponse)
-def get_my_feedback_for_activity(
-    activity_id: int,
-    db: Session = Depends(get_db),
-    user: dict = Depends(get_current_user(force_auth=False))
-):
-    user_id = user.get("sub") if user else user.get("anonymous_id")
-    feedback = db.query(FeedbackModel).filter_by(activity_id=activity_id, user_id=user_id).first()
-    if not feedback:
-        raise HTTPException(status_code=404, detail="No feedback found for this activity and user")
-    return feedback
-
+def get_my_feedback_for_activity(activity_id: int, db: Session = Depends(get_db), user: dict = Depends(get_current_user(force_auth=False))):
+    return FeedbackService(db).get_by_user_and_activity(activity_id, user)
 
 @router.put("/{activity_id}", response_model=FeedbackResponse)
-def update_my_feedback_for_activity(
-    activity_id: int,
-    data: FeedbackCreate,
-    db: Session = Depends(get_db),
-    user: dict = Depends(get_current_user(force_auth=False))
-):
-    user_id = user.get("sub") if user else user.get("anonymous_id")
-
-    feedback = db.query(FeedbackModel).filter_by(activity_id=activity_id, user_id=user_id).first()
-    if not feedback:
-        raise HTTPException(status_code=404, detail="Feedback not found to update")
-
-    feedback.rating = data.rating
-    feedback.comment = data.comment
-
-    db.commit()
-    db.refresh(feedback)
-    return feedback
-
+def update_my_feedback(activity_id: int, data: FeedbackCreate, db: Session = Depends(get_db), user: dict = Depends(get_current_user(force_auth=False))):
+    return FeedbackService(db).update(activity_id, data, user)
 
 @router.delete("/{activity_id}", response_model=FeedbackResponse)
-def delete_my_feedback_for_activity(
-    activity_id: int,
-    db: Session = Depends(get_db),
-    user: dict = Depends(get_current_user(force_auth=False))
-):
-    user_id = user.get("sub") if user else user.get("anonymous_id")
-
-    feedback = db.query(FeedbackModel).filter_by(activity_id=activity_id, user_id=user_id).first()
-    if not feedback:
-        raise HTTPException(status_code=404, detail="Feedback not found to delete")
-
-    db.delete(feedback)
-    db.commit()
-    return feedback
+def delete_my_feedback(activity_id: int, db: Session = Depends(get_db), user: dict = Depends(get_current_user(force_auth=False))):
+    return FeedbackService(db).delete(activity_id, user)

--- a/schemas/feedback_component.py
+++ b/schemas/feedback_component.py
@@ -10,4 +10,4 @@ class FeedbackFormComponent(BaseComponentSchema):
     submit_button: Button = Field(default=None, description="Submit button")
     rating_scale: int = Field(default=5, description="Rating scale")
     show_comment_box: bool = Field(default=True, description="Show comment box")
-    require_auth: bool = Field(default=True, description="Require authentication")
+    require_auth: bool = Field(default=False, description="Require authentication")

--- a/schemas/feedback_component.py
+++ b/schemas/feedback_component.py
@@ -5,9 +5,9 @@ from schemas.ui.components.button import Button
 from pydantic import Field
 
 class FeedbackFormComponent(BaseComponentSchema):
-    title: Title = Field(..., description="Form title")
-    description: Text = Field(..., description="Description feedback form")
-    submit_button: Button = Field(..., description="Submit button")
+    title: Title = Field(default="Feedback Form", description="Component title")
+    description: Text = Field(default=None, description="Component description")
+    submit_button: Button = Field(default=None, description="Submit button")
     rating_scale: int = Field(default=5, description="Rating scale")
     show_comment_box: bool = Field(default=True, description="Show comment box")
     require_auth: bool = Field(default=True, description="Require authentication")

--- a/services/feedback_service.py
+++ b/services/feedback_service.py
@@ -1,0 +1,68 @@
+from sqlalchemy.orm import Session
+from fastapi import HTTPException
+from typing import List, Optional
+from datetime import datetime, timedelta
+from models.activity import Activity
+from ..models.feedback import Feedback as FeedbackModel
+from ..schemas.feedback import FeedbackCreate
+from services.ui.plugin_settings import get_plugin_setting_by_title
+from ..utils.feedback import get_user_id, ensure_activity_has_ended
+
+class FeedbackService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def get_all(self) -> List[FeedbackModel]:
+        return self.db.query(FeedbackModel).all()
+
+    def get_by_activity(self, activity_id: int) -> List[FeedbackModel]:
+        return self.db.query(FeedbackModel).filter_by(activity_id=activity_id).all()
+
+    def get_by_user_and_activity(self, activity_id: int, user: dict) -> FeedbackModel:
+        user_id = get_user_id(user)
+        feedback = self.db.query(FeedbackModel).filter_by(activity_id=activity_id, user_id=user_id).first()
+        if not feedback:
+            raise HTTPException(status_code=404, detail="No feedback found for this activity and user")
+        return feedback
+
+    async def create(self, activity_id: int, data: FeedbackCreate, user: dict) -> FeedbackModel:
+        user_id = get_user_id(user)
+        activity = self.db.query(Activity).filter(Activity.id == activity_id).first()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
+
+        ensure_activity_has_ended(activity)
+
+        existing = self.db.query(FeedbackModel).filter_by(activity_id=activity_id, user_id=user_id).first()
+        if existing:
+            raise HTTPException(status_code=400, detail="User has already submitted feedback for this activity")
+
+        settings = await get_plugin_setting_by_title("activities-feedback-plugin")
+        inputs = {input.title: input for input in settings.inputs}
+
+        if inputs.get("Require Rating") and inputs["Require Rating"].options[0] == "Yes":
+            if not (1 <= data.rating <= 5):
+                raise HTTPException(status_code=400, detail="Rating is required and must be between 1 and 5.")
+
+        if inputs.get("Allow Comments") and inputs["Allow Comments"].options[0] == "No":
+            data.comment = None
+
+        feedback = FeedbackModel(activity_id=activity_id, rating=data.rating, comment=data.comment, user_id=user_id)
+        self.db.add(feedback)
+        self.db.commit()
+        self.db.refresh(feedback)
+        return feedback
+
+    def update(self, activity_id: int, data: FeedbackCreate, user: dict) -> FeedbackModel:
+        feedback = self.get_by_user_and_activity(activity_id, user)
+        feedback.rating = data.rating
+        feedback.comment = data.comment
+        self.db.commit()
+        self.db.refresh(feedback)
+        return feedback
+
+    def delete(self, activity_id: int, user: dict) -> FeedbackModel:
+        feedback = self.get_by_user_and_activity(activity_id, user)
+        self.db.delete(feedback)
+        self.db.commit()
+        return feedback

--- a/utils/feedback.py
+++ b/utils/feedback.py
@@ -1,0 +1,11 @@
+from fastapi import HTTPException
+from datetime import datetime, timedelta
+from models.activity import Activity
+
+def get_user_id(user: dict) -> str:
+    return user.get("sub") if user else user.get("anonymous_id")
+
+def ensure_activity_has_ended(activity: Activity):
+    end_time = activity.date + timedelta(minutes=activity.duration)
+    if datetime.utcnow() < end_time:
+        raise HTTPException(status_code=400, detail="Feedback can only be submitted after the activity has ended.")


### PR DESCRIPTION
This pull request refactors the feedback system by introducing a new `FeedbackService` class to centralize business logic, simplifies the API router, and updates the feedback schema to provide better defaults. The changes aim to improve code maintainability, enforce stricter validation, and enhance user experience.

### Refactoring and Centralization:
* Introduced `FeedbackService` in `services/feedback_service.py` to handle all feedback-related operations, including creating, updating, deleting, and retrieving feedback. This centralizes business logic previously scattered across the router.
* Moved utility functions such as `get_user_id` and `ensure_activity_has_ended` to `utils/feedback.py` for better reusability and separation of concerns.

### Simplification of API Router:
* Refactored `router/feedback.py` to delegate feedback operations to `FeedbackService`, significantly reducing code duplication and simplifying the router. For instance, the `submit_feedback` endpoint now directly calls `FeedbackService.create`.

### Schema Enhancements:
* Updated `FeedbackFormComponent` in `schemas/feedback_component.py` to include default values for fields like `title`, `description`, and `submit_button`. Additionally, changed `require_auth` to default to `False` to make authentication optional by default.

### Database Updates:
* Modified the `Feedback` model in `models/feedback.py` to make `activity_id` nullable and enforce a foreign key constraint with the `Activity` model. This ensures database integrity while allowing for more flexible feedback associations.