### PR TITLE
refactor to new way to create settings

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,30 +1,34 @@
 from .router import router
 from .schemas.feedback_component import FeedbackFormComponent
 from services.component_registry import ComponentRegistry
-from services.ui.plugin_settings import create_plugin_setting, delete_plugin_setting_by_title
-from schemas.plugin_setting import PluginSetting, SelectorInput
+from services.ui.plugin_settings import create_plugin_setting, delete_plugin_setting_by_title, generate_inputs_from_settings
+from schemas.plugin_setting import PluginSetting
+from pydantic import BaseModel, Field
 import logging
 
 logger = logging.getLogger("coffeebreak.activity-feedback")
 
 PLUGIN_TITLE = "activities-feedback-plugin"
-PLUGIN_DESCRIPTION = "This plugin allows participants to submit feedback with a rating and optional comments."
+NAME = "Activities Feedback Plugin"
+DESCRIPTION = "This plugin allows participants to submit feedback with a rating and optional comments."
 
-# Options for the plugin settings
-plugin_inputs = [
-    SelectorInput(
-        type="selector",
+class Settings(BaseModel):
+    allow_comments: bool = Field(
+        default=True,
         title="Allow Comments",
         description="Allow users to add a comment to their feedback",
         options=["Yes", "No"]
-    ),
-    SelectorInput(
-        type="selector",
+    )
+    require_rating: bool = Field(
+        default=True,
         title="Require Rating",
         description="Require users to submit a rating (1 to 5)",
         options=["Yes", "No"]
     )
-]
+
+SETTINGS = Settings()
+
+plugin_inputs = generate_inputs_from_settings(Settings)
 
 async def register_plugin():
     ComponentRegistry.register_component(FeedbackFormComponent)
@@ -32,7 +36,8 @@ async def register_plugin():
 
     setting = PluginSetting(
         title=PLUGIN_TITLE,
-        description=PLUGIN_DESCRIPTION,
+        name=NAME,
+        description=DESCRIPTION,
         inputs=plugin_inputs
     )
     await create_plugin_setting(setting)
@@ -46,6 +51,3 @@ async def unregister_plugin():
 
 REGISTER = register_plugin
 UNREGISTER = unregister_plugin
-
-SETTINGS = {}
-DESCRIPTION = PLUGIN_DESCRIPTION


### PR DESCRIPTION
This pull request refactors the plugin initialization code in `__init__.py` to improve maintainability and consistency. The most important changes include replacing hardcoded plugin settings with a `Pydantic` model, renaming constants for clarity, and simplifying the generation of plugin inputs.

### Refactoring plugin settings:

* Introduced a `Settings` class using `Pydantic` to define plugin settings (`allow_comments` and `require_rating`) with default values and metadata (`title` and `description`). This replaces the previous hardcoded `SelectorInput` definitions. (`[__init__.pyL4-R40](diffhunk://#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cL4-R40)`)
* Replaced the manual `plugin_inputs` list with a dynamically generated one using the new `generate_inputs_from_settings` function. (`[__init__.pyL4-R40](diffhunk://#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cL4-R40)`)

### Naming and structure improvements:

* Renamed constants `PLUGIN_TITLE` and `PLUGIN_DESCRIPTION` to `NAME` and `DESCRIPTION` for better semantic clarity. (`[__init__.pyL4-R40](diffhunk://#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cL4-R40)`)
* Removed redundant `SETTINGS` and `DESCRIPTION` assignments in the `unregister_plugin` function, as they were no longer necessary. (`[__init__.pyL49-L51](diffhunk://#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cL49-L51)`)