### PR TITLE
Activity id cascade and 5 allow feedback 5 minutes before end

### DIFF
--- a/models/feedback.py
+++ b/models/feedback.py
@@ -5,7 +5,7 @@ class Feedback(Base):
     __tablename__ = "feedbacks"
 
     id = Column(Integer, primary_key=True, index=True)
-    activity_id = Column(Integer, ForeignKey("activities.id"), nullable=True)
+    activity_id = Column(Integer, ForeignKey("activities.id", ondelete="CASCADE"), nullable=True)
     rating = Column(Integer, nullable=True)
     comment = Column(Text, nullable=True)
     user_id = Column(String, nullable=False)

--- a/utils/feedback.py
+++ b/utils/feedback.py
@@ -7,5 +7,6 @@ def get_user_id(user: dict) -> str:
 
 def ensure_activity_has_ended(activity: Activity):
     end_time = activity.date + timedelta(minutes=activity.duration)
-    if datetime.utcnow() < end_time:
-        raise HTTPException(status_code=400, detail="Feedback can only be submitted after the activity has ended.")
+    feedback_allowed_time = end_time - timedelta(minutes=5)
+    if datetime.utcnow() < feedback_allowed_time:
+        raise HTTPException(status_code=400, detail="Feedback can only be submitted in the last 5 minutes of the activity or after it has ended.")


### PR DESCRIPTION
This pull request introduces changes to improve feedback handling in the system. The most notable updates include enforcing stricter deletion rules for feedback associated with activities and modifying the timing logic for when feedback can be submitted.

### Feedback model updates:
* In `models/feedback.py`, the `activity_id` column now uses `ondelete="CASCADE"` for its foreign key constraint, ensuring that feedback entries are automatically deleted when the associated activity is removed.

### Feedback submission logic updates:
* In `utils/feedback.py`, the `ensure_activity_has_ended` function has been updated to allow feedback submission during the last 5 minutes of an activity in addition to after it has ended, enhancing flexibility for users.

**Related Jira Ticket:** SCRUM-363