### PR TITLE
feat: integrate coffeebreak SDK, i18n, admin page, and fix settings reading

### DIFF
--- a/services/feedback_service.py
+++ b/services/feedback_service.py
@@ -5,8 +5,9 @@ from datetime import datetime, timedelta
 from coffeebreak.models import ActivityModel as Activity
 from ..models.feedback import Feedback as FeedbackModel
 from ..schemas.feedback import FeedbackCreate
-from coffeebreak.services.ui.plugin_settings import get_plugin_setting_by_title
+from coffeebreak.services.plugin_service import get_plugin_settings
 from ..utils.feedback import get_user_id, ensure_activity_has_ended
+
 
 class FeedbackService:
     def __init__(self, db: Session):
@@ -20,12 +21,20 @@ class FeedbackService:
 
     def get_by_user_and_activity(self, activity_id: int, user: dict) -> FeedbackModel:
         user_id = get_user_id(user)
-        feedback = self.db.query(FeedbackModel).filter_by(activity_id=activity_id, user_id=user_id).first()
+        feedback = (
+            self.db.query(FeedbackModel)
+            .filter_by(activity_id=activity_id, user_id=user_id)
+            .first()
+        )
         if not feedback:
-            raise HTTPException(status_code=404, detail="No feedback found for this activity and user")
+            raise HTTPException(
+                status_code=404, detail="No feedback found for this activity and user"
+            )
         return feedback
 
-    async def create(self, activity_id: int, data: FeedbackCreate, user: dict) -> FeedbackModel:
+    async def create(
+        self, activity_id: int, data: FeedbackCreate, user: dict
+    ) -> FeedbackModel:
         user_id = get_user_id(user)
         activity = self.db.query(Activity).filter(Activity.id == activity_id).first()
         if not activity:
@@ -33,27 +42,45 @@ class FeedbackService:
 
         ensure_activity_has_ended(activity)
 
-        existing = self.db.query(FeedbackModel).filter_by(activity_id=activity_id, user_id=user_id).first()
+        existing = (
+            self.db.query(FeedbackModel)
+            .filter_by(activity_id=activity_id, user_id=user_id)
+            .first()
+        )
         if existing:
-            raise HTTPException(status_code=400, detail="User has already submitted feedback for this activity")
+            raise HTTPException(
+                status_code=400,
+                detail="User has already submitted feedback for this activity",
+            )
 
-        settings = await get_plugin_setting_by_title("activities-feedback-plugin")
-        inputs = {input.title: input for input in settings.inputs}
+        plugin_settings = get_plugin_settings("activities-feedback-plugin")
+        require_rating = plugin_settings.get("require_rating", True)
+        allow_comments = plugin_settings.get("allow_comments", True)
 
-        if inputs.get("Require Rating") and inputs["Require Rating"].default:
+        if require_rating:
             if not (1 <= data.rating <= 5):
-                raise HTTPException(status_code=400, detail="Rating is required and must be between 1 and 5.")
+                raise HTTPException(
+                    status_code=400,
+                    detail="Rating is required and must be between 1 and 5.",
+                )
 
-        if inputs.get("Allow Comments") and not inputs["Allow Comments"].default:
+        if not allow_comments:
             data.comment = None
-            
-        feedback = FeedbackModel(activity_id=activity_id, rating=data.rating, comment=data.comment, user_id=user_id)
+
+        feedback = FeedbackModel(
+            activity_id=activity_id,
+            rating=data.rating,
+            comment=data.comment,
+            user_id=user_id,
+        )
         self.db.add(feedback)
         self.db.commit()
         self.db.refresh(feedback)
         return feedback
 
-    def update(self, activity_id: int, data: FeedbackCreate, user: dict) -> FeedbackModel:
+    def update(
+        self, activity_id: int, data: FeedbackCreate, user: dict
+    ) -> FeedbackModel:
         feedback = self.get_by_user_and_activity(activity_id, user)
         feedback.rating = data.rating
         feedback.comment = data.comment


### PR DESCRIPTION
## Summary

- Integrate coffeebreak SDK and add i18n support (en, pt-PT, pt-BR) for both admin and event-app components
- Add admin page with activity feedback overview, rating breakdown, filtering, search, and pagination
- Add `FeedbackFormComponent` as a registered plugin component for the event-app
- Fix `feedback_service.py` to use `get_plugin_settings()` instead of reading MongoDB form defaults (which broke after plugin settings persistence was added to core)
- Add `pyproject.toml` manifest entries for admin page, components dir, and component registration

## Changes

- **`admin/Page.jsx`** (new): Full admin dashboard with activity cards, feedback detail view, rating distribution, user/rating filters, pagination
- **`components/FeedbackFormComponent.jsx`** (new): Reusable feedback form with star rating, comment box, submit/update logic
- **`locales/{en,pt-BR,pt-PT}.json`** (new): Translation files for all user-facing strings
- **`services/feedback_service.py`**: Use `get_plugin_settings()` from `plugin_service` instead of deprecated `get_plugin_setting_by_title` from MongoDB UI form defaults
- **`pyproject.toml`**: Add `components_dir`, `admin_page`, and `components` configuration
- **`.gitignore`**: Ignore `.build/` directory
- **`.talismanrc`**: Suppress false-positive secret warnings